### PR TITLE
bugfix : ESLint에러 수정, windows10 CRLF에러

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,5 +11,12 @@
       "jsx": true
     }
   },
-  "rules": {}
+  "rules": {
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
+  }
 }

--- a/config/webpackDevServer.config.js
+++ b/config/webpackDevServer.config.js
@@ -14,8 +14,7 @@ const sockPath = process.env.WDS_SOCKET_PATH; // default: '/ws'
 const sockPort = process.env.WDS_SOCKET_PORT;
 
 module.exports = function (proxy, allowedHost) {
-  const disableFirewall =
-    !proxy || process.env.DANGEROUSLY_DISABLE_HOST_CHECK === 'true';
+  const disableFirewall = true;
   return {
     // WebpackDevServer 2.4.3 introduced a security fix that prevents remote
     // websites from potentially accessing local content through DNS rebinding:


### PR DESCRIPTION
윈도우환경에서 실행시 엔드라인시퀀스 에러로 CRLF마다 에러로그가 출력되는 에러 해결, 윈도우 노트북 배포를 위한 수정